### PR TITLE
Remove donate box

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -2,7 +2,7 @@
 
   <p>For 19 years, <em>The Brooklyn Rail</em> has never wavered in its commitment to providing an accessible and independent forum for the arts. 2019 has been a particularly monumental year for the <em>Rail</em>, with curatorial projects at both the <a href="https://venice.brooklynrail.org">Venice Biennale</a> and the <a href="https://www.colby.edu/museum/exhibition/occupy-colby-artists-need-to-create-on-the-same-scale-that-society-has-the-capacity-to-destroy-year-2/">Colby Museum</a>, two special issues of the River Rail, <a href="https://shop.brooklynrail.org">three new releases from our literary press Rail Editions</a>, and the continued publication of our <a href="https://brooklynrail.org/subscribe">ten annual issues</a>, now read each month by 200,000 individuals around the world.</p>
 
-  <p><strong>Please donate to help keep the <em>Rail</em> independent and free for all.</strong></p>
+  <p>Please send an email to <a href="mailto:hq@brooklynrail.org">hq@brooklynrail.org</a> if you're interested in helping to <strong>keep the <em>Rail</em> independent and free for all.</strong></p>
 
   <p class="newsletter"><strong><a href="https://mailchi.mp/brooklynrail/join/?donate_page">Sign up for our newsletter</a></strong> to learn about upcoming issues and projects in 2020.</p>
 

--- a/templates/checkouts/layout.php
+++ b/templates/checkouts/layout.php
@@ -25,15 +25,11 @@ $supportPath = $this->data["support_path"];
       <section class="page-top">
         <div class="grid-container grid-container-desktop-lg">
           <div class="grid-row grid-gap-4">
-            <div class="grid-col-12 tablet-lg:grid-col-7">
+            <div class="grid-col-12 tablet-lg:grid-col-8 tablet-lg:grid-offset-2">
               <div class="video-container">
                 <iframe width="650" height="365" src="https://www.youtube.com/embed/QeNzahu3ooE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
               </div>
               <?php require_once("includes/content.php"); ?>
-            </div>
-            <div class="grid-col-12 tablet-lg:grid-col-5">
-              <?php require_once("includes/goals.php"); ?>
-              <?php require_once("includes/donate.php"); ?>
             </div>
           </div>
         </div>


### PR DESCRIPTION
I was unsuccessful at putting up a captcha that would sufficiently stop hackers from using the donate box as a way to test out stolen credit cards. 😢😞

### How bad was it?
**Since Jan 1, 2020**, there have been over 245,782 fraudulent credit card attempts on our donate page. Braintree is on the verge of closing down our account, and we could incur fines if we do not remove the donate box.

This PR removes it, and inserts an email option.